### PR TITLE
Update Dockerfile to add unrar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN set -eux; \
     apt-get install -y locales; \
     locale-gen en_US.UTF-8; \
     locale; \
-    apt-get install -y curl sudo openssl; \
+    apt-get install -y curl sudo openssl unrar; \
     apt-get autoremove -y; \
     apt-get clean -y; \
     rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
Add unrar to the installed packages to allow for rar files in torrents to be extracted